### PR TITLE
JSONエクスポート時にディレクトリの存在を確認して，存在しない場合は作成するようにした

### DIFF
--- a/export.go
+++ b/export.go
@@ -3,14 +3,28 @@ package main
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 )
+
+// fileExists はファイルの存在を確認する
+func fileExists(name string) bool {
+	_, err := os.Stat(name)
+
+	return !os.IsNotExist(err)
+}
 
 // exportToJson は店舗情報をJSONにエクスポートする
 func exportToJson(stores []Store, filePath string) error {
 	jsonData, err := json.Marshal(stores)
-
 	if err != nil {
 		return err
+	}
+
+	dirname := filepath.Dir(filePath)
+	if !fileExists(dirname) {
+		if err := os.MkdirAll(dirname, os.ModePerm); err != nil {
+			return err
+		}
 	}
 
 	f, err := os.Create(filePath)


### PR DESCRIPTION
JSONエクスポート時にディレクトリが存在しない場合はエラーになってしまうため，ファイル作成前にディレクトリのチェックを行うようにした。

ディレクトリが存在しない場合はディレクトリを作成する。