### PR TITLE
JSONエクスポートでファイルを使い終わった後にファイルを閉じる処理を追加

### DIFF
--- a/export.go
+++ b/export.go
@@ -31,10 +31,11 @@ func exportToJson(stores []Store, filePath string) error {
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 
 	if _, err = f.Write(jsonData); err != nil {
 		return err
 	}
 
-	return nil
+	return f.Sync()
 }


### PR DESCRIPTION
JSONエクスポートでファイルを使い終わった後にファイルを閉じる処理を追加。

`defer f.Close()`だけではなく，`f.Sync()`を呼んだ方が良いっぽいのでそうした。